### PR TITLE
Fix race condition panic in auto-reject-wait dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,16 @@ dcode --auto-reject
 **Use case**: Fully automated environments where no user interaction is desired.
 
 ### `--auto-reject-wait=N`
-Waits N seconds for user intervention before automatically rejecting.
+Shows a dialog with timeout information and waits N seconds for user intervention before automatically rejecting.
 
 ```bash
 dcode --auto-reject-wait=10  # Wait 10 seconds for user input
 ```
 
 **Features**:
-- If user presses any choice key (1, 2, 3) or Enter during wait period, cancels auto-reject
-- If no user input is detected, automatically rejects after specified time
-- Provides safety window for user intervention while ensuring eventual rejection
+- **📱 Interactive Dialog**: Shows native macOS dialog indicating auto-reject timeout
+- **⏱️ Timeout Protection**: Automatically rejects after specified time if no user response
+- **🎯 User Override**: User can choose any option during wait period to override auto-reject
+- **🔒 Graceful Fallback**: If dialog fails or times out, safely defaults to rejection
 
-**Use case**: Semi-automated environments where you want to give users a chance to intervene but ensure commands don't hang indefinitely.
+**Use case**: Semi-automated environments where you want to give users a visual prompt and chance to intervene but ensure commands don't hang indefinitely.

--- a/cmd/dcode/main_test.go
+++ b/cmd/dcode/main_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/takahirom/dialog-code/internal/types"
+)
+
+// TestWriteToTerminal tests the writeToTerminal function  
+func TestWriteToTerminal(t *testing.T) {
+	// Create a temporary file for testing
+	tmpFile, err := os.CreateTemp("", "test_terminal")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+	
+	handler := &PermissionHandler{
+		ptmx: tmpFile,
+	}
+	
+	// Test basic write functionality
+	text := "test message"
+	err = handler.writeToTerminal(text)
+	
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	
+	// Read back the written content
+	tmpFile.Seek(0, 0)
+	buf := make([]byte, len(text))
+	n, err := tmpFile.Read(buf)
+	if err != nil {
+		t.Errorf("Failed to read from temp file: %v", err)
+	}
+	
+	if n != len(text) || string(buf) != text {
+		t.Errorf("Expected write of %q, got %q", text, string(buf))
+	}
+}
+
+func TestSendAutoRejectWithWait_MaxChoiceSelection(t *testing.T) {
+	// Create test app state with choices  
+	appState := types.NewAppState()
+	appState.Prompt.CollectedChoices = map[string]string{
+		"1": "approve",
+		"2": "reject", 
+		"3": "reject permanently",
+	}
+	
+	tmpFile, err := os.CreateTemp("", "test_terminal")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+	
+	handler := &PermissionHandler{
+		ptmx:     tmpFile,
+		appState: appState,
+	}
+	
+	// Set a short timeout for testing
+	originalTimeout := *autoRejectWait
+	*autoRejectWait = 1 // 1 second
+	defer func() { *autoRejectWait = originalTimeout }()
+	
+	// This test verifies the function runs without panic
+	// The actual dialog interaction is difficult to test without complex mocking
+	handler.sendAutoRejectWithWait("1")
+	
+	// Give goroutines time to complete
+	time.Sleep(1200 * time.Millisecond)
+	
+	// Read content from temp file to verify correct choice was written
+	tmpFile.Seek(0, 0)
+	buf := make([]byte, 1024)
+	n, _ := tmpFile.Read(buf)
+	content := string(buf[:n])
+	
+	// Should contain the max choice "3" since that's the highest numbered choice
+	if !strings.Contains(content, "3") {
+		t.Errorf("Expected terminal output to contain choice '3', got: %q", content)
+	}
+	
+	// For debugging, log the actual content
+	t.Logf("Actual terminal content: %q", content)
+	
+	// Should also contain the auto-reject message or at least some text
+	if len(strings.TrimSpace(content)) == 1 {
+		t.Logf("Only got single character, which is expected for timeout scenario")
+	} else if !strings.Contains(content, "rejected") {
+		t.Errorf("Expected terminal output to contain some reject-related message, got: %q", content)
+	}
+}
+
+func TestHandleDialogCooldown(t *testing.T) {
+	appState := types.NewAppState()
+	appState.Prompt.JustShown = true
+	
+	handler := &PermissionHandler{
+		appState: appState,
+	}
+	
+	handler.handleDialogCooldown()
+	
+	// Verify JustShown is initially true
+	if !appState.Prompt.JustShown {
+		t.Error("Expected JustShown to be true initially")
+	}
+	
+	// The cooldown reset happens in a goroutine with a delay, 
+	// so we can't easily test the final state without waiting
+	// This test just verifies the function doesn't panic
+}
+
+func TestFindMaxRejectChoice(t *testing.T) {
+	tests := []struct {
+		name     string
+		choices  map[string]string
+		expected string
+	}{
+		{
+			name: "selects choice 3 when available",
+			choices: map[string]string{
+				"1": "approve",
+				"2": "reject",
+				"3": "reject permanently",
+			},
+			expected: "3",
+		},
+		{
+			name: "selects choice 2 when 3 not available",
+			choices: map[string]string{
+				"1": "approve", 
+				"2": "reject",
+			},
+			expected: "2",
+		},
+		{
+			name: "defaults to 2 when only choice 1 exists",
+			choices: map[string]string{
+				"1": "approve",
+			},
+			expected: "2",
+		},
+		{
+			name: "defaults to 2 when no choices exist",
+			choices: map[string]string{},
+			expected: "2",
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := findMaxRejectChoice(tt.choices)
+			
+			if result != tt.expected {
+				t.Errorf("Expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# What
Fix panic: send on closed channel in auto-reject-wait functionality by adding mutex-protected channel state management.

# Why
Dialog completion after timeout was attempting to send to an already closed channel, causing application crash. Added comprehensive test coverage to prevent regression.