### PR TITLE
Move countdown message to top of dialogs

### DIFF
--- a/cmd/dcode/app.go
+++ b/cmd/dcode/app.go
@@ -423,7 +423,7 @@ func (p *PermissionHandler) sendAutoRejectWithWait(bestChoice string) {
 		// Show dialog with countdown in a separate goroutine
 		go func() {
 			baseMessage := p.buildDialogMessage(p.appState.Prompt.LastLine, p.appState.Prompt.Context, p.appState.Prompt.TriggerReason)
-			countdownMsg := fmt.Sprintf("%s\n\nThis will auto-reject in %d seconds...", baseMessage, *autoRejectWait)
+			countdownMsg := fmt.Sprintf("This will auto-reject in %d seconds...\n\n%s", *autoRejectWait, baseMessage)
 			buttons := p.extractButtons()
 			defaultButton := ""
 			if len(buttons) > 0 {

--- a/cmd/dcode/app_robot.go
+++ b/cmd/dcode/app_robot.go
@@ -177,3 +177,33 @@ func (r *AppRobot) GetCapturedMessageWithoutTimestamp() string {
 	}
 	return actualMessage
 }
+
+// SetAutoRejectWait sets the auto-reject timeout for testing
+// This allows AppRobot to test auto-reject functionality
+func (r *AppRobot) SetAutoRejectWait(seconds int) *AppRobot {
+	// TODO: Add mutex protection for thread-safe access to global autoRejectWait
+	*autoRejectWait = seconds
+	return r
+}
+
+// TriggerAutoReject triggers auto-reject functionality with the configured timeout
+func (r *AppRobot) TriggerAutoReject(bestChoice string) *AppRobot {
+	// Set up the handler's app state with the captured data
+	handler := r.app.handler
+	
+	// Trigger auto-reject dialog
+	handler.sendAutoRejectWithWait(bestChoice)
+	
+	// Give goroutines time to complete
+	// TODO: Replace magic sleep value with named constant
+	time.Sleep(100 * time.Millisecond)
+	
+	return r
+}
+
+// RestoreAutoRejectWait restores the original auto-reject timeout (for cleanup)
+func (r *AppRobot) RestoreAutoRejectWait(originalTimeout int) *AppRobot {
+	// TODO: Add mutex protection for thread-safe access to global autoRejectWait
+	*autoRejectWait = originalTimeout
+	return r
+}

--- a/cmd/dcode/main_test.go
+++ b/cmd/dcode/main_test.go
@@ -282,3 +282,4 @@ func TestSendAutoRejectWithWait_DialogAfterTimeout(t *testing.T) {
 		t.Error("Expected some content to be written during timeout scenario")
 	}
 }
+


### PR DESCRIPTION
# What
Repositioned auto-reject countdown messages to appear at the top of permission dialogs instead of at the bottom, improving user experience by making the timeout more visible.

# Why
When using auto-reject functionality, users need to see the countdown timer immediately to understand they have limited time to make a choice. Placing it at the top ensures better visibility and UX.