### PR TITLE
Use parseDialogBox for structured AutoRejectMessage command extraction

### DIFF
--- a/cmd/dcode/main_test.go
+++ b/cmd/dcode/main_test.go
@@ -107,7 +107,7 @@ func TestSendAutoRejectWithWait_MaxChoiceSelection(t *testing.T) {
 	handler.sendAutoRejectWithWait("1")
 
 	// Give goroutines time to complete
-	time.Sleep(1200 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	// Read content from temp file to verify correct choice was written
 	tmpFile.Seek(0, 0)
@@ -262,7 +262,7 @@ func TestSendAutoRejectWithWait_DialogAfterTimeout(t *testing.T) {
 	handler.sendAutoRejectWithWait("1")
 
 	// Wait longer than timeout to ensure any lingering goroutines complete
-	time.Sleep(2000 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 
 	// Verify timeout behavior occurred correctly
 	tmpFile.Seek(0, 0)

--- a/internal/choice/choice.go
+++ b/internal/choice/choice.go
@@ -260,3 +260,8 @@ func GetCleanDialogMessage(prompt string, context []string, triggerReason string
 	dialogInfo := parseDialogBox(context, regexPatterns)
 	return formatCleanMessage(triggerText, timestamp, triggerReason, dialogInfo)
 }
+
+// ParseDialogBox extracts command information from dialog box context (public wrapper)
+func ParseDialogBox(context []string, regexPatterns *types.RegexPatterns) DialogBoxInfo {
+	return parseDialogBox(context, regexPatterns)
+}


### PR DESCRIPTION
# What
Refactored buildAutoRejectMessage to use choice.ParseDialogBox for structured command extraction instead of manual line processing.

# Why
The previous implementation used manual line-by-line filtering which was fragile and allowed dialog decorations to leak through. Using the existing parseDialogBox function provides proper structured parsing that cleanly extracts command details while filtering out dialog UI elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of command lines to prevent decorative or numbered dialog choices from appearing in auto-reject messages.
  * Resolved issues where pipe characters could leak into auto-reject messages.

* **New Features**
  * Enhanced message parsing by introducing a dedicated dialog box parsing function for more consistent extraction of command details.

* **Tests**
  * Added new tests to verify that auto-reject messages are correctly cleaned and free of unwanted characters or formatting.
  * Reduced wait times in some tests to speed up test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->