### PR TITLE
Fix false positive dialog detection for non-dialog text

### DIFF
--- a/cmd/dcode/app_robot.go
+++ b/cmd/dcode/app_robot.go
@@ -71,6 +71,13 @@ func (r *AppRobot) AssertDialogCaptured() *AppRobot {
 	return r
 }
 
+func (r *AppRobot) AssertNoDialogCaptured() *AppRobot {
+	if r.dialog.GetCapturedMessage() != "" {
+		r.t.Errorf("Expected no dialog to be captured, but got: %q", r.dialog.GetCapturedMessage())
+	}
+	return r
+}
+
 // AssertDialogTextContains verifies dialog message contains expected text
 func (r *AppRobot) AssertDialogTextContains(expectedText string) *AppRobot {
 	capturedMessage := r.dialog.GetCapturedMessage()

--- a/internal/choice/BUILD.bazel
+++ b/internal/choice/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/takahirom/dialog-code/internal/choice",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/debug",
         "//internal/types",
     ],
 )

--- a/internal/choice/choice.go
+++ b/internal/choice/choice.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/takahirom/dialog-code/internal/debug"
 	"github.com/takahirom/dialog-code/internal/types"
 )
 
@@ -39,6 +40,7 @@ func GetBestChoice(choices map[string]string, regexPatterns *types.RegexPatterns
 	}
 
 	// Ultimate fallback
+	debug.Printf("[DEBUG] GetBestChoice: No valid choice found in %v, returning default \"1\"\n", choices)
 	return "1"
 }
 

--- a/internal/dialog/BUILD.bazel
+++ b/internal/dialog/BUILD.bazel
@@ -8,4 +8,7 @@ go_library(
     ],
     importpath = "github.com/takahirom/dialog-code/internal/dialog",
     visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/debug",
+    ],
 )

--- a/internal/dialog/simple_dialog.go
+++ b/internal/dialog/simple_dialog.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+
+	"github.com/takahirom/dialog-code/internal/debug"
 )
 
 // SimpleOSDialog provides pure OS dialog functionality without message processing
@@ -52,9 +54,9 @@ func (d *SimpleOSDialog) executeAppleScriptDialog(message string, buttons []stri
 	output, err := cmd.Output()
 	if err != nil {
 		// AppleScript execution failed, default to first button (safe choice)
+		debug.Printf("[DEBUG] SimpleOSDialog: AppleScript error: %v, returning \"1\"\n", err)
 		return "1"
 	}
-	
 	
 	// Parse the result to find which button was clicked
 	return d.parseAppleScriptResult(string(output), buttons)
@@ -85,5 +87,6 @@ func (d *SimpleOSDialog) parseAppleScriptResult(output string, buttons []string)
 	}
 	
 	// Default to first button if parsing fails
+	debug.Printf("[DEBUG] SimpleOSDialog: No button match found, returning default \"1\"\n")
 	return "1"
 }


### PR DESCRIPTION
# What
Add dialog box boundary detection to prevent "Do you want" text outside dialog boxes from triggering permission dialogs

# Why
Text like "Do you want to make this edit" appearing outside dialog boxes was incorrectly triggering dialog detection and causing "1" to be input to the terminal