### PR TITLE
Adjust auto-reject timing delay

### DIFF
--- a/cmd/dcode/main.go
+++ b/cmd/dcode/main.go
@@ -33,7 +33,7 @@ const (
 
 	// Auto-reject timing constants
 	AutoRejectChoiceDelayMs  = 500
-	AutoRejectCRDelayMs      = 400
+	AutoRejectCRDelayMs      = 600
 	AutoRejectProcessDelayMs = 500
 
 	// Auto-reject base message


### PR DESCRIPTION
# What
Increased AutoRejectCRDelayMs from 400ms to 600ms.

# Why
Improved timing reliability for auto-reject carriage return delay to ensure proper terminal interaction.