### PR TITLE
Fix infinite loop with non-breaking space in input boxes

### DIFF
--- a/cmd/dcode/app.go
+++ b/cmd/dcode/app.go
@@ -347,7 +347,8 @@ func (p *PermissionHandler) isInsideDialogBox(line string) bool {
 // Input boxes have the pattern "│ >" which is different from dialog choices "│ ❯"
 func (p *PermissionHandler) isInputBox(line string) bool {
 	// Check if current line or recent context has input box pattern
-	if strings.Contains(line, "│ >") || strings.Contains(line, "> Rejected") {
+	// Note: Claude Code uses non-breaking space (U+00A0) around the ">"
+	if strings.Contains(line, "│ >") || strings.Contains(line, "│\u00a0>") || strings.Contains(line, "> Rejected") {
 		return true
 	}
 	
@@ -361,6 +362,7 @@ func (p *PermissionHandler) isInputBox(line string) bool {
 	
 	for i := startIdx; i < contextLen; i++ {
 		if strings.Contains(p.contextLines[i], "│ >") || 
+		   strings.Contains(p.contextLines[i], "│\u00a0>") ||
 		   strings.Contains(p.contextLines[i], "> Rejected") {
 			return true
 		}

--- a/cmd/dcode/auto_reject_loop_test.go
+++ b/cmd/dcode/auto_reject_loop_test.go
@@ -36,4 +36,69 @@ func TestAutoRejectLoopPrevention(t *testing.T) {
 
 		t.Logf("✓ Dialog box containing rejection message handled correctly")
 	})
+
+	t.Run("Claude Code input box with 'Do you want to' text", func(t *testing.T) {
+		// This simulates Claude Code's input box displaying "Do you want to" text
+		inputBoxWithDoYouWant := []string{
+			"╭──────────────────────────────────────────────────────────────────────────────╮",
+			"│ > Do you want to proceed with the changes?                                  │",
+			"╰──────────────────────────────────────────────────────────────────────────────╯",
+		}
+
+		robot := NewAppRobot(t).
+			ReceiveClaudeText(inputBoxWithDoYouWant...)
+
+		// This should NOT be detected as a dialog (it's an input box with >)
+		robot.AssertNoDialogCaptured()
+
+		// No dialog choices should be sent  
+		terminalOutput := robot.GetTerminalOutput()
+		if strings.Contains(terminalOutput, "1") || strings.Contains(terminalOutput, "2") {
+			t.Errorf("Input box with 'Do you want to' triggered false detection: %q", terminalOutput)
+		}
+
+		t.Logf("✓ Input box with 'Do you want to' handled correctly")
+	})
+
+	t.Run("Claude outputs 'Do you want to make this edit' in input box", func(t *testing.T) {
+		// Input box with regular space separator
+		claudeOutputInInputBox := []string{
+			"╭──────────────────────────────────────────────────────────────────────────────╮",
+			"│ > Do you want to make this edit to file.txt?                                │",
+			"╰──────────────────────────────────────────────────────────────────────────────╯",
+		}
+
+		robot := NewAppRobot(t).
+			ReceiveClaudeText(claudeOutputInInputBox...)
+
+		robot.AssertNoDialogCaptured()
+
+		terminalOutput := robot.GetTerminalOutput()
+		if strings.Contains(terminalOutput, "1") || strings.Contains(terminalOutput, "2") {
+			t.Errorf("Claude's 'Do you want to make this edit' in input box triggered dialog detection: %q", terminalOutput)
+		}
+
+		t.Logf("✓ Claude's 'Do you want to make this edit' in input box handled correctly")
+	})
+
+	t.Run("Input box with non-breaking space", func(t *testing.T) {
+		// Claude Code uses non-breaking space (U+00A0) instead of regular space
+		bugScenario := []string{
+			"╭──────────────────────────────────────────────────────────────────────────────╮",
+			"│\u00a0>\u00a0Do you want to edit                                                        │",
+			"╰──────────────────────────────────────────────────────────────────────────────╯",
+		}
+
+		robot := NewAppRobot(t).
+			ReceiveClaudeText(bugScenario...)
+
+		robot.AssertNoDialogCaptured()
+
+		terminalOutput := robot.GetTerminalOutput()
+		if strings.Contains(terminalOutput, "1") || strings.Contains(terminalOutput, "2") {
+			t.Errorf("Input box with non-breaking space triggered dialog detection: %q", terminalOutput)
+		}
+
+		t.Logf("✓ Input box with non-breaking space handled correctly")
+	})
 }


### PR DESCRIPTION
# What
Fixed infinite loop caused by Claude Code using non-breaking spaces (U+00A0) in input boxes

# Why
Claude Code's input boxes use `│\u00a0>\u00a0` pattern instead of regular spaces, causing them to be misdetected as dialogs, triggering auto-reject and creating an infinite loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved detection of on-screen input boxes, including non‑breaking space variants, to avoid misinterpreting displayed prompts as interactive dialogs. This reduces accidental prompt handling and better matches the UI’s rendering, without affecting real dialog behavior.
- Tests
  - Added coverage for input‑box edge cases and Unicode spacing variations to ensure prompts shown in boxes are not treated as dialogs and to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->